### PR TITLE
remove dot alias from test

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1,8 +1,9 @@
 package evdev_test
 
 import (
-	. "evdev"
 	"fmt"
+
+	evdev "github.com/gvalkov/golang-evdev"
 )
 
 func ExampleOpen() {


### PR DESCRIPTION
When I run `go mod tidy` on my project, it raises a following error:

```
$ go mod tidy
...
        github.com/gvalkov/golang-evdev tested by                                                                                                                                                                 
        github.com/gvalkov/golang-evdev.test imports                                                                                                                                                              
        evdev: malformed module path "evdev": missing dot in first path element                            
```

I fixed it by changing dot import to absolute one.