### PR TITLE
Add functions to read the current value of input elements

### DIFF
--- a/bin/evtest.go
+++ b/bin/evtest.go
@@ -131,7 +131,13 @@ func main() {
 	// for ctype, codes := range dev.Capabilities {
 	// 	fmt.Printf("  Type %s %d\n", ctype.Name, ctype.Type)
 	// 	for i := range codes {
-	// 		fmt.Printf("   Code %d %s\n", codes[i].Code, codes[i].Name)
+	// 		element := evdev.InputElement{ctype.Type, codes[i].Code}
+	// 		state, ok := dev.InitState[element]
+	// 		stateString := ""
+	// 		if ok {
+	// 			stateString = fmt.Sprintf("[init state %d]", state)
+	// 		}
+	// 		fmt.Printf("   Code %d %s %s\n", codes[i].Code, codes[i].Name, stateString)
 	// 	}
 	// }
 

--- a/cdefs.go
+++ b/cdefs.go
@@ -58,10 +58,10 @@ var EVIOCGPHYS = C._EVIOCGPHYS(MAX_NAME_SIZE) // get physical location
 var EVIOCGUNIQ = C._EVIOCGUNIQ(MAX_NAME_SIZE) // get unique identifier
 var EVIOCGPROP = C._EVIOCGPROP(MAX_NAME_SIZE) // get device properties
 
-var EVIOCGKEY = C._EVIOCGKEY(MAX_NAME_SIZE) // get global key state
-var EVIOCGLED = C._EVIOCGLED(MAX_NAME_SIZE) // get all LEDs
-var EVIOCGSND = C._EVIOCGSND(MAX_NAME_SIZE) // get all sounds status
-var EVIOCGSW = C._EVIOCGSW(MAX_NAME_SIZE)   // get all switch states
+func EVIOCGKEY(l int) int { return int(C._EVIOCGSW(C.int(l))) }  // get global key state
+func EVIOCGLED(l int) int { return int(C._EVIOCGLED(C.int(l))) } // get all LEDs
+func EVIOCGSND(l int) int { return int(C._EVIOCGSND(C.int(l))) } // get all sounds status
+func EVIOCGSW(l int) int  { return int(C._EVIOCGSW(C.int(l))) }  // get all switch states
 
 func EVIOCGBIT(ev, l int) int { return int(C._EVIOCGBIT(C.int(ev), C.int(l))) } // get event bits
 func EVIOCGABS(abs int) int   { return int(C._EVIOCGABS(C.int(abs))) }          // get abs bits


### PR DESCRIPTION
In many applications, it's impractical to rely on input events to occur on a specific device as their state might change only occasionally, but a program needs to know about the current state of the hardware. Most commonly that is the case for `SW` and `ABS` input types.

This PR brings that functionality in by using the appropriate `ioctl` calls on the opened input device handle. The initial state after opening the device is exposed in the new exported `InitState` member of the `InputDevice` struct.